### PR TITLE
chore: Update documentation for new embedded info modal

### DIFF
--- a/v1.md
+++ b/v1.md
@@ -13,8 +13,8 @@ If you like, you can set the domains that will be allowed to embed the dashboard
 **Note: Leaving the Allowed Domains field empty will allow embedding from any domain.**
     
 You will be shown your Embedded Dashboard ID, Superset Domain, Workspace ID, and Team ID, which you will need for the following steps.
-<img width="753" alt="Screen_Shot_2022-04-01_at_1 06 48_PM" src="https://user-images.githubusercontent.com/1858430/163030747-0a37a7f5-86d3-4e2c-b66a-9c1b62f43cfb.png">
-**replace with updated screenshot ^^^**
+
+![Screen Shot 2022-08-31 at 10 30 36 AM](https://user-images.githubusercontent.com/47196419/187742568-789c953e-986e-49e2-9aa3-756c99b35779.png)
 
 
 

--- a/v1.md
+++ b/v1.md
@@ -2,20 +2,6 @@ Embedding dashboards offers a lot of customization options to fit your security 
 
 ## Step 0: Gather the Preset asset information
 
-### How to Get Team ID
-The easiest way to get your Team ID is to go to the Manage Team button on the Preset Homepage.  From here, you can gather the team name through the last part of the displayed URL:
-
-![Screen Shot 2022-04-13 at 3 29 20 PM](https://user-images.githubusercontent.com/3037961/163280634-ef841e3b-b761-457a-b69c-cb546040e172.png)
-
-
-### How to Get Workspace Domain & Embedded Dashboard ID
-
-Visit your dashboard. 
-
-In the URL, the subdomain slug at the very beginning is your **Workspace ID**. The portion after it is the **Workspace Region**.
-
-<img width="555" alt="163274230-075a9fde-652f-489b-8d96-8f232fad53dc" src="https://user-images.githubusercontent.com/1858430/163280204-08c5f3c3-827e-4f63-8e05-f504b28e5fb1.png">
-
 In the sub-menu, select **Embed Dashboard**
     
 <img width="897" alt="Screen_Shot_2022-04-01_at_12 59 31_PM" src="https://user-images.githubusercontent.com/1858430/163030810-51683190-65f1-4136-bd9b-533ebd3c7b98.png">
@@ -23,18 +9,18 @@ In the sub-menu, select **Embed Dashboard**
 If you like, you can set the domains that will be allowed to embed the dashboard. When you are ready, click **Enable Embedding.**
     
 <img width="915" alt="Screen_Shot_2022-04-01_at_1 04 48_PM" src="https://user-images.githubusercontent.com/1858430/163030717-6e6bf2ac-e4ae-4ac3-b77a-2ad4b9245280.png">
-    
-Copy the ID shown to use as the resource id in the guest token API and to the front-end `embedDashboard` function.
 
 **Note: Leaving the Allowed Domains field empty will allow embedding from any domain.**
     
+You will be shown your Embedded Dashboard ID, Superset Domain, Workspace ID, and Team ID, which you will need for the following steps.
 <img width="753" alt="Screen_Shot_2022-04-01_at_1 06 48_PM" src="https://user-images.githubusercontent.com/1858430/163030747-0a37a7f5-86d3-4e2c-b66a-9c1b62f43cfb.png">
+**replace with updated screenshot ^^^**
 
 
 
 ## Step 1: (Back-end) Creating Guest Tokens
 
-A Guest Token authenticates an end user to access an embedded dashboard. Guest tokens are created by calling the Manager endpoint `POST` `https://manage.app.preset.io/api/v1/teams/<TEAM NAME>/workspaces/<WORKSPACE NAME>/guest-token/` from your back-end service.
+A Guest Token authenticates an end user to access an embedded dashboard. Guest tokens are created by calling the Manager endpoint `POST` `https://manage.app.preset.io/api/v1/teams/<TEAM_ID>/workspaces/<WORKSPACE_ID>/guest-token/` from your back-end service.
 
 To make this request, you will first need to [authenticate with the Preset API](https://docs.preset.io/docs/using-the-preset-api) and get an access token. Access tokens have a short lifetime of a few hours, so in a long-running service, they’ll need to be refreshed periodically using your API Key.
 
@@ -51,14 +37,14 @@ A python example creating a Guest Token:
 	  },
 	  "resources": [{
 	    "type": "dashboard",
-	    "id": EMBEDDED_DASHBOARD_ID
+	    "id": <EMBEDDED_DASHBOARD_ID>
 	  }],
 	  "rls": []
 	}
 
 	response = requests.post(
-		"https://manage.app.preset.io/api/v1/teams/<TEAM NAME>/workspaces" +
-		"/<WORKSPACE NAME>/guest-token/",
+		"https://manage.app.preset.io/api/v1/teams/<TEAM_ID>/workspaces" +
+		"/<WORKSPACE_ID>/guest-token/",
 		data=payload,
 		headers={ "Authorization": my_preset_access_token }
 	).json()
@@ -120,7 +106,7 @@ def get_guest_token():
 	  },
 	  "resources": [{
 	    "type": "dashboard",
-	    "id": EMBEDDED_DASHBOARD_ID
+	    "id": <EMBEDDED_DASHBOARD_ID>
 	  }],
 	  "rls": [
 	    { "clause": f"user_id = '{g.user.id}'" }
@@ -128,8 +114,8 @@ def get_guest_token():
 	}
 
 	token_response = requests.post(
-		"https://manage.app.preset.io/api/v1/teams/<TEAM NAME>/workspaces" +
-		"/<WORKSPACE NAME>/guest-token/",
+		"https://manage.app.preset.io/api/v1/teams/<TEAM_ID>/workspaces" +
+		"/<WORKSPACE_ID>/guest-token/",
 		data=payload,
 		headers={ "Authorization": preset_access_token }
 	).json()
@@ -169,8 +155,8 @@ When using ES6 imports or a build tool:
 import { embedDashboard } from "@preset-sdk/embedded";
 
 embedDashboard({
-  id: "6f03195d-0bf6-47a7-b44e-baa7636ac128", // given by the Superset embedding UI
-  supersetDomain: "https://{WORKSPACE NAME}.{WORKSPACE REGION}.app.preset.io",
+  id: <EMBEDDED_DASHBOARD_ID>,
+  supersetDomain: <SUPERSET_DOMAIN>,
   mountPoint: document.getElementById("my-superset-container"), // any html element that can contain an iframe
   fetchGuestToken: () => fetchGuestTokenFromBackend(),
   dashboardUiConfig: { hideTitle: true }, // dashboard UI config: hideTitle, hideTab, hideChartControls (optional)
@@ -183,8 +169,8 @@ Using a script tag with CDN:
 
 <script>
 	presetSdk.embedDashboard({
-	  id: "abc123", // given by the Superset embedding UI
-	  supersetDomain: "https://{WORKSPACE NAME}.{WORKSPACE REGION}.app.preset.io",
+	  id: <EMBEDDED_DASHBOARD_ID>,
+	  supersetDomain: <SUPERSET_DOMAIN>,
 	  mountPoint: document.getElementById("my-superset-container"), // any html element that can contain an iframe
 	  fetchGuestToken: () => fetchGuestTokenFromBackend(),
 	  dashboardUiConfig: { hideTitle: true }, // dashboard UI config: hideTitle, hideTab, hideChartControls (optional)


### PR DESCRIPTION
The embedded info modal we show will be updated to look something like this:
![Screen Shot 2022-08-10 at 11 20 54 PM](https://user-images.githubusercontent.com/47196419/184075122-07135db5-47e2-428f-ba26-d0b213bc9a3a.png)

This PR updates this documentation accordingly.

Related ticket: https://app.shortcut.com/preset/story/52994/add-additional-information-into-embed-dashboard-modal